### PR TITLE
fix: gracefully handle stale ctx after session replacement

### DIFF
--- a/src/hook-context.ts
+++ b/src/hook-context.ts
@@ -30,6 +30,35 @@ export type HookModuleContext = {
   ) => Promise<void>;
 };
 
+/**
+ * Check if an error is a stale-context error from pi session replacement.
+ * This happens when `-p` or similar causes a session reload while an
+ * extension handler is still running with the old ctx.
+ */
+export function isStaleContextError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /stale after session replacement/i.test(err.message);
+}
+
+/**
+ * Wrap an async event handler so stale-context errors are silently ignored.
+ * When a session is replaced mid-handler (e.g. `pi -p`), the captured ctx
+ * becomes invalid. There's nothing useful to do at that point — the session
+ * the handler was serving no longer exists.
+ */
+export function safeHandler<A, R>(
+  fn: (event: A, ctx: any) => Promise<R>,
+): (event: A, ctx: any) => Promise<R | undefined> {
+  return async (event: A, ctx: any): Promise<R | undefined> => {
+    try {
+      return await fn(event, ctx);
+    } catch (err) {
+      if (isStaleContextError(err)) return undefined;
+      throw err;
+    }
+  };
+}
+
 export function createHookContext(pi: ExtensionAPI): HookModuleContext {
   const shared: HookModuleContext = {
     pi,

--- a/src/hooks/compact-hooks.ts
+++ b/src/hooks/compact-hooks.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { HookModuleContext } from "../hook-context";
+import { type HookModuleContext, safeHandler } from "../hook-context";
 import type {
   HookExecutionContext,
   HookRunResult,
@@ -18,7 +18,7 @@ async function triggerCompactHooks(
 }
 
 export function registerCompactHooks(pi: ExtensionAPI, shared: HookModuleContext) {
-  pi.on("session_before_compact", async (event, ctx) => {
+  pi.on("session_before_compact", safeHandler(async (event, ctx) => {
     const trigger: "manual" | "auto" = "manual";
     await triggerCompactHooks(
       "PreCompact",
@@ -33,9 +33,9 @@ export function registerCompactHooks(pi: ExtensionAPI, shared: HookModuleContext
       shared.currentSettings,
       (msg, type) => shared.notify(ctx, msg, type),
     );
-  });
+  }));
 
-  pi.on("session_compact", async (event, ctx) => {
+  pi.on("session_compact", safeHandler(async (event, ctx) => {
     const trigger: "manual" | "auto" = "manual";
 
     await triggerCompactHooks(
@@ -53,5 +53,5 @@ export function registerCompactHooks(pi: ExtensionAPI, shared: HookModuleContext
     );
 
     await shared.triggerSessionStartHook("compact", ctx);
-  });
+  }));
 }

--- a/src/hooks/prompt-hooks.ts
+++ b/src/hooks/prompt-hooks.ts
@@ -1,6 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getHookGroups } from "../config";
-import type { HookModuleContext } from "../hook-context";
+import { type HookModuleContext, safeHandler } from "../hook-context";
 import type {
   HookExecutionContext,
   NotifyFn,
@@ -84,7 +84,7 @@ export function registerPromptHooks(
   pi: ExtensionAPI,
   shared: HookModuleContext,
 ) {
-  pi.on("input", async (event, ctx) => {
+  pi.on("input", safeHandler(async (event, ctx) => {
     shared.pendingUserPromptContext = undefined;
     shared.stopHookActive = false;
 
@@ -114,9 +114,9 @@ export function registerPromptHooks(
     }
 
     return { action: "continue" } as const;
-  });
+  }));
 
-  pi.on("before_agent_start", async (_event, _ctx) => {
+  pi.on("before_agent_start", safeHandler(async (_event, _ctx) => {
     if (!shared.pendingUserPromptContext) {
       return;
     }
@@ -134,5 +134,5 @@ export function registerPromptHooks(
         },
       },
     };
-  });
+  }));
 }

--- a/src/hooks/session-hooks.ts
+++ b/src/hooks/session-hooks.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import type { HookModuleContext } from "../hook-context";
+import { type HookModuleContext, safeHandler } from "../hook-context";
 import type {
   HookExecutionContext,
   HookMatcherValue,
@@ -31,7 +31,7 @@ export function registerSessionHooks(
   //
   // SessionEnd 映射：
   // other -> session_shutdown
-  pi.on("session_start", async (event, ctx) => {
+  pi.on("session_start", safeHandler(async (event, ctx) => {
     shared.initSettings(ctx.cwd);
 
     if (event.reason === "startup" || event.reason === "new") {
@@ -42,9 +42,9 @@ export function registerSessionHooks(
     if (event.reason === "resume") {
       await shared.triggerSessionStartHook("resume", ctx);
     }
-  });
+  }));
 
-  pi.on("session_shutdown", async (_event, ctx) => {
+  pi.on("session_shutdown", safeHandler(async (_event, ctx) => {
     const reason = "other";
 
     // SessionEnd 固定由 session_shutdown 触发，matcher 仅使用 other。
@@ -60,5 +60,5 @@ export function registerSessionHooks(
       shared.currentSettings,
       (msg, type) => shared.notify(ctx, msg, type),
     );
-  });
+  }));
 }

--- a/src/hooks/stop-hooks.ts
+++ b/src/hooks/stop-hooks.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getHookGroups } from "../config";
 import { extractTextFromContent } from "../helpers";
-import type { HookModuleContext } from "../hook-context";
+import { type HookModuleContext, safeHandler } from "../hook-context";
 import type {
   HookExecutionContext,
   NotifyFn,
@@ -98,7 +98,7 @@ export async function triggerStopHooks(
 }
 
 export function registerStopHooks(pi: ExtensionAPI, shared: HookModuleContext) {
-  pi.on("agent_end", async (event, ctx) => {
+  pi.on("agent_end", safeHandler(async (event, ctx) => {
     const result = await triggerStopHooks(
       {
         sessionId: shared.getSessionId(ctx),
@@ -137,5 +137,5 @@ export function registerStopHooks(pi: ExtensionAPI, shared: HookModuleContext) {
     }
 
     shared.stopHookActive = false;
-  });
+  }));
 }

--- a/src/hooks/tool-hooks.ts
+++ b/src/hooks/tool-hooks.ts
@@ -1,7 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { getHookGroups, matcherMatches } from "../config";
 import { extractErrorFromContent } from "../helpers";
-import type { HookModuleContext } from "../hook-context";
+import { type HookModuleContext, safeHandler } from "../hook-context";
 import type {
   HookExecutionContext,
   NotifyFn,
@@ -240,7 +240,7 @@ export async function triggerPostToolUseFailureHooks(
 }
 
 export function registerToolHooks(pi: ExtensionAPI, shared: HookModuleContext) {
-  pi.on("tool_call", async (event, ctx) => {
+  pi.on("tool_call", safeHandler(async (event, ctx) => {
     const result = await triggerPreToolUseHooks(
       event.toolName,
       {
@@ -277,9 +277,9 @@ export function registerToolHooks(pi: ExtensionAPI, shared: HookModuleContext) {
         toolUseId: event.toolCallId,
       });
     }
-  });
+  }));
 
-  pi.on("tool_result", async (event, ctx): Promise<any> => {
+  pi.on("tool_result", safeHandler(async (event, ctx): Promise<any> => {
     if (event.isError) {
       const result = await triggerPostToolUseFailureHooks(
         event.toolName,
@@ -364,5 +364,5 @@ export function registerToolHooks(pi: ExtensionAPI, shared: HookModuleContext) {
         isError: result.isError ?? event.isError,
       } as any;
     }
-  });
+  }));
 }


### PR DESCRIPTION
## Problem

When running `pi -p "prompt"`, the extension throws an error after the response is delivered:

```
Extension error (.../pi-hooks.ts): This extension ctx is stale after session replacement or reload.
Do not use a captured pi or command ctx after ctx.newSession(), ctx.fork(), ctx.switchSession(),
or ctx.reload().
```

The `-p` flag causes pi to create a session, run the prompt, then replace/reload the session. The extension's event handlers still hold a reference to the old `ctx` and try to use it after replacement.

## Fix

Add a `safeHandler` wrapper in `hook-context.ts` that catches stale-context errors and returns silently. When a session is replaced mid-handler, the old session no longer exists — there is nothing useful the handler can do, so silently returning is the correct behavior.

All 9 `pi.on()` registrations across 5 hook modules are wrapped:

- `session-hooks.ts` — `session_start`, `session_shutdown`
- `prompt-hooks.ts` — `input`, `before_agent_start`
- `compact-hooks.ts` — `session_before_compact`, `session_compact`
- `stop-hooks.ts` — `agent_end`
- `tool-hooks.ts` — `tool_call`, `tool_result`

## Testing

```bash
# Before fix: prints response + error
pi -p "hello world"
# => Hello! 👋 ...
# => Extension error (...): This extension ctx is stale...

# After fix: clean output
pi -p "hello world"
# => Hello! 👋 ...
```