### PR TITLE
fix: resolve bash via settings shellPath to avoid WSL on Windows

### DIFF
--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { GLOBAL_SETTINGS_PATH, readSettingsFile } from "./config";
 import type { Hook, HookExecutionContext } from "./types";
 
 // ============================================================================
@@ -98,6 +100,33 @@ export async function executeHook(
   return executeCommandHook(hook.command, inputJson, cwd, timeoutMs);
 }
 
+/**
+ * Resolve the bash executable, mirroring Pi's own shell resolution
+ * (utils/shell.js getShellConfig): settings shellPath first, then known
+ * Git Bash locations, then PATH as a last resort.
+ */
+function resolveBash(): string {
+  const settings = readSettingsFile(GLOBAL_SETTINGS_PATH);
+  if (settings?.shellPath && existsSync(settings.shellPath)) {
+    return settings.shellPath;
+  }
+  const candidates: Array<string | undefined> = [
+    process.env.ProgramFiles
+      ? `${process.env.ProgramFiles}/Git/bin/bash.exe`
+      : undefined,
+    process.env["ProgramFiles(x86)"]
+      ? `${process.env["ProgramFiles(x86)"]}/Git/bin/bash.exe`
+      : undefined,
+    "C:/msys64/usr/bin/bash.exe",
+  ];
+  for (const candidate of candidates) {
+    if (candidate && existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return "bash";
+}
+
 function executeCommandHook(
   command: string,
   inputJson: string,
@@ -105,7 +134,7 @@ function executeCommandHook(
   timeoutMs: number,
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve) => {
-    const child = spawn("bash", ["-c", command], {
+    const child = spawn(resolveBash(), ["-c", command], {
       cwd,
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export type HooksConfig = {
 
 export type SettingsFile = {
   hooks?: HooksConfig;
+  shellPath?: string;
 };
 
 export type HookEventName =


### PR DESCRIPTION
Fixes #3

## Problem

On Windows, command hooks fail silently with exit 127 because `spawn("bash")` resolves to the WSL launcher (`C:\Windows\System32\bash.exe`) instead of Git Bash. WSL runs a Linux distro that cannot see Node.js or Windows paths.

## Change

Add `resolveBash()` in `src/executor.ts`, mirroring Pi's own shell resolution (`utils/shell.js getShellConfig`):

1. `shellPath` from `~/.pi/agent/settings.json` (same source Pi uses)
2. Known Git Bash locations (`ProgramFiles`, `ProgramFiles(x86)`, MSYS2)
3. `bash` (PATH) as a last resort

Also add `shellPath?: string` to `SettingsFile` in `src/types.ts`.

## Validation

- `pnpm exec tsc --noEmit` passes (strict).
