### PR TITLE
feat: make hook notification messages configurable via settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,28 @@ Notes:
   - `updatedMCPToolOutput` (for MCP tool output replacement)
   - `hookSpecificOutput.updatedMCPToolOutput`
 
+## Custom Messages
+
+All user-facing notification strings (e.g. `PreToolUse 阻止: …`) can be
+overridden with a top-level `messages` key. Keys are listed in
+`src/messages.ts`; unset keys fall back to the built-in defaults, so existing
+configs keep working unchanged. Templates accept `{reason}`, `{output}`,
+`{stderr}`, `{error}`, `{exitCode}`, and `{decision}` placeholders.
+
+```json
+{
+  "hooks": { "Stop": [{ "hooks": [{ "type": "command", "command": "..." }] }] },
+  "messages": {
+    "preToolUseBlocked": "Blocked: {reason}",
+    "stopError": "Stop hook crashed: {error}",
+    "defaultBlockedReason": "Denied by policy"
+  }
+}
+```
+
+`messages` merges like `hooks`: project settings override the global
+settings per key.
+
 ## Usage
 
 ### Local development
@@ -565,6 +587,7 @@ Source code lives in `src/`:
 - `src/hooks/tool-hooks.ts` - `PreToolUse` / `PostToolUse` / `PostToolUseFailure`
 - `src/hooks/stop-hooks.ts` - `Stop`
 - `src/types.ts` - type definitions
+- `src/messages.ts` - default notification strings + `{var}` formatting
 
 ## Notes
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -530,6 +530,26 @@ Pi 扩展层也支持直接 patch 工具结果：
   - `updatedMCPToolOutput`（用于 MCP 工具输出替换）
   - `hookSpecificOutput.updatedMCPToolOutput`
 
+## 自定义通知文本
+
+所有面向用户的通知文本（例如 `PreToolUse 阻止: …`）都可以通过顶层 `messages`
+键覆盖。可用的键定义在 `src/messages.ts` 中；未设置的键沿用内置默认值，
+现有配置不受影响。模板支持 `{reason}`、`{output}`、`{stderr}`、`{error}`、
+`{exitCode}` 和 `{decision}` 占位符。
+
+```json
+{
+  "hooks": { "Stop": [{ "hooks": [{ "type": "command", "command": "..." }] }] },
+  "messages": {
+    "preToolUseBlocked": "Blocked: {reason}",
+    "stopError": "Stop hook crashed: {error}",
+    "defaultBlockedReason": "Denied by policy"
+  }
+}
+```
+
+`messages` 与 `hooks` 的合并规则一致：项目配置按 key 覆盖全局配置。
+
 ## 使用方法
 
 ### 本地开发
@@ -565,6 +585,7 @@ pi install npm:@hsingjui/pi-hooks
 - `src/hooks/tool-hooks.ts` - `PreToolUse` / `PostToolUse` / `PostToolUseFailure`
 - `src/hooks/stop-hooks.ts` - `Stop`
 - `src/types.ts` - 类型定义
+- `src/messages.ts` - 默认通知文本 + `{var}` 格式化
 
 ## 说明
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,13 +87,19 @@ export function loadSettings(cwd: string): {
   );
 
   const hooks = mergeHooks(globalSettings?.hooks, projectSettings?.hooks);
+  // Project-level message overrides win per-key over global ones.
+  const messages = {
+    ...globalSettings?.messages,
+    ...projectSettings?.messages,
+  };
+  const hasMessages = Object.keys(messages).length > 0;
 
-  if (!hooks) {
+  if (!hooks && !hasMessages) {
     return { settings: undefined, sourcePaths };
   }
 
   return {
-    settings: { hooks },
+    settings: { hooks, ...(hasMessages ? { messages } : {}) },
     sourcePaths,
   };
 }

--- a/src/hooks/prompt-hooks.ts
+++ b/src/hooks/prompt-hooks.ts
@@ -7,6 +7,7 @@ import type {
   SettingsFile,
   UserPromptSubmitResult,
 } from "../types";
+import { formatMessage, resolveMessages } from "../messages";
 import {
   appendAdditionalContext,
   executeParsedHook,
@@ -20,6 +21,7 @@ export async function triggerUserPromptSubmitHooks(
   notify?: NotifyFn,
 ): Promise<UserPromptSubmitResult> {
   const groups = getHookGroups(settings, "UserPromptSubmit");
+  const msg = resolveMessages(settings);
   const result: UserPromptSubmitResult = { blocked: false };
 
   for (const group of groups) {
@@ -50,7 +52,9 @@ export async function triggerUserPromptSubmitHooks(
             jsonOutput.decision !== "block"
           ) {
             notify?.(
-              `UserPromptSubmit 忽略无效 decision: ${String(jsonOutput.decision)}`,
+              formatMessage(msg.userPromptSubmitInvalidDecision, {
+                decision: String(jsonOutput.decision),
+              }),
               "warning",
             );
           }
@@ -58,21 +62,32 @@ export async function triggerUserPromptSubmitHooks(
           if (jsonOutput.decision === "block") {
             result.blocked = true;
             result.reason =
-              getStringField(jsonOutput.reason) ?? "Blocked by hook";
+              getStringField(jsonOutput.reason) ?? msg.defaultBlockedReason;
             return result;
           }
         } else if (hookResult.exitCode === 0 && plainStdout) {
-          notify?.(`UserPromptSubmit 输出 (非JSON): ${plainStdout}`, "info");
+          notify?.(
+            formatMessage(msg.userPromptSubmitPlainOutput, {
+              output: plainStdout,
+            }),
+            "info",
+          );
         }
 
         if (hookResult.exitCode !== 0) {
           notify?.(
-            `UserPromptSubmit 失败 (exit ${hookResult.exitCode}): ${hookResult.stderr}`,
+            formatMessage(msg.userPromptSubmitFailed, {
+              exitCode: hookResult.exitCode,
+              stderr: hookResult.stderr,
+            }),
             "error",
           );
         }
       } catch (err) {
-        notify?.(`UserPromptSubmit 执行错误: ${String(err)}`, "error");
+        notify?.(
+          formatMessage(msg.userPromptSubmitError, { error: String(err) }),
+          "error",
+        );
       }
     }
   }
@@ -101,9 +116,12 @@ export function registerPromptHooks(
     );
 
     if (result.blocked) {
+      const blockMsg = resolveMessages(shared.currentSettings);
       shared.notify(
         ctx,
-        `UserPromptSubmit 阻止: ${result.reason ?? "Blocked by hook"}`,
+        formatMessage(blockMsg.userPromptSubmitBlocked, {
+          reason: result.reason ?? blockMsg.defaultBlockedReason,
+        }),
         "warning",
       );
       return { action: "handled" } as const;

--- a/src/hooks/shared.ts
+++ b/src/hooks/shared.ts
@@ -1,5 +1,6 @@
 import { getHookGroups, matcherMatches } from "../config";
 import { buildHookInput, executeHook } from "../executor";
+import { formatMessage, resolveMessages } from "../messages";
 import type {
   Hook,
   HookExecutionContext,
@@ -227,6 +228,7 @@ export async function triggerSimpleHooks(
   notify?: NotifyFn,
 ): Promise<HookRunResult> {
   const groups = getHookGroups(settings, eventName);
+  const msg = resolveMessages(settings);
   const aggregatedResult: HookRunResult = {};
 
   for (const group of groups) {
@@ -271,7 +273,10 @@ export async function triggerSimpleHooks(
 
         if (hookResult.exitCode !== 0) {
           notify?.(
-            `Hook 失败 (exit ${hookResult.exitCode}): ${hookResult.stderr}`,
+            formatMessage(msg.hookFailed, {
+              exitCode: hookResult.exitCode,
+              stderr: hookResult.stderr,
+            }),
             "error",
           );
         } else if (
@@ -280,10 +285,16 @@ export async function triggerSimpleHooks(
           !jsonOutput &&
           commonOutput?.suppressOutput !== true
         ) {
-          notify?.(`Hook 输出: ${plainStdout}`, "info");
+          notify?.(
+            formatMessage(msg.hookOutput, { output: plainStdout }),
+            "info",
+          );
         }
       } catch (err) {
-        notify?.(`Hook 执行错误: ${String(err)}`, "error");
+        notify?.(
+          formatMessage(msg.hookError, { error: String(err) }),
+          "error",
+        );
       }
     }
   }

--- a/src/hooks/stop-hooks.ts
+++ b/src/hooks/stop-hooks.ts
@@ -8,6 +8,7 @@ import type {
   SettingsFile,
   StopResult,
 } from "../types";
+import { formatMessage, resolveMessages } from "../messages";
 import {
   appendAdditionalContext,
   executeParsedHook,
@@ -36,6 +37,7 @@ export async function triggerStopHooks(
   notify?: NotifyFn,
 ): Promise<StopResult> {
   const groups = getHookGroups(settings, "Stop");
+  const msg = resolveMessages(settings);
   const result: StopResult = { blocked: false };
 
   for (const group of groups) {
@@ -66,7 +68,9 @@ export async function triggerStopHooks(
             jsonOutput.decision !== "block"
           ) {
             notify?.(
-              `Stop 忽略无效 decision: ${String(jsonOutput.decision)}`,
+              formatMessage(msg.stopInvalidDecision, {
+                decision: String(jsonOutput.decision),
+              }),
               "warning",
             );
           }
@@ -74,22 +78,30 @@ export async function triggerStopHooks(
           if (jsonOutput.decision === "block") {
             result.blocked = true;
             result.reason =
-              getStringField(jsonOutput.reason) ??
-              "Continue requested by Stop hook";
+              getStringField(jsonOutput.reason) ?? msg.stopBlockReason;
             return result;
           }
         } else if (hookResult.exitCode === 0 && plainStdout) {
-          notify?.(`Stop 输出 (非JSON): ${plainStdout}`, "info");
+          notify?.(
+            formatMessage(msg.stopPlainOutput, { output: plainStdout }),
+            "info",
+          );
         }
 
         if (hookResult.exitCode !== 0) {
           notify?.(
-            `Stop 失败 (exit ${hookResult.exitCode}): ${hookResult.stderr}`,
+            formatMessage(msg.stopFailed, {
+              exitCode: hookResult.exitCode,
+              stderr: hookResult.stderr,
+            }),
             "error",
           );
         }
       } catch (err) {
-        notify?.(`Stop 执行错误: ${String(err)}`, "error");
+        notify?.(
+          formatMessage(msg.stopError, { error: String(err) }),
+          "error",
+        );
       }
     }
   }

--- a/src/hooks/tool-hooks.ts
+++ b/src/hooks/tool-hooks.ts
@@ -9,6 +9,7 @@ import type {
   PreToolUseResult,
   SettingsFile,
 } from "../types";
+import { formatMessage, resolveMessages } from "../messages";
 import {
   appendAdditionalContext,
   executeParsedHook,
@@ -24,6 +25,7 @@ export async function triggerPreToolUseHooks(
   notify?: NotifyFn,
 ): Promise<PreToolUseResult> {
   const groups = getHookGroups(settings, "PreToolUse");
+  const msg = resolveMessages(settings);
   const result: PreToolUseResult = { blocked: false };
 
   for (const group of groups) {
@@ -38,8 +40,11 @@ export async function triggerPreToolUseHooks(
 
         if (hookResult.exitCode === 2) {
           result.blocked = true;
-          result.reason = hookResult.stderr || "Blocked by hook";
-          notify?.(`PreToolUse 阻止: ${result.reason}`, "warning");
+          result.reason = hookResult.stderr || msg.defaultBlockedReason;
+          notify?.(
+            formatMessage(msg.preToolUseBlocked, { reason: result.reason }),
+            "warning",
+          );
           return result;
         }
 
@@ -63,8 +68,11 @@ export async function triggerPreToolUseHooks(
             result.blocked = true;
             result.reason = (hookSpecific?.permissionDecisionReason ??
               jsonOutput.permissionDecisionReason) as string | undefined;
-            result.reason ??= "Blocked by hook";
-            notify?.(`PreToolUse 拒绝: ${result.reason}`, "warning");
+            result.reason ??= msg.defaultBlockedReason;
+            notify?.(
+              formatMessage(msg.preToolUseDenied, { reason: result.reason }),
+              "warning",
+            );
             return result;
           }
 
@@ -86,17 +94,26 @@ export async function triggerPreToolUseHooks(
             additionalContext,
           );
         } else if (hookResult.exitCode === 0 && plainStdout) {
-          notify?.(`PreToolUse 输出 (非JSON): ${plainStdout}`, "info");
+          notify?.(
+            formatMessage(msg.preToolUsePlainOutput, { output: plainStdout }),
+            "info",
+          );
         }
 
         if (hookResult.exitCode !== 0 && hookResult.exitCode !== 2) {
           notify?.(
-            `PreToolUse 失败 (exit ${hookResult.exitCode}): ${hookResult.stderr}`,
+            formatMessage(msg.preToolUseFailed, {
+              exitCode: hookResult.exitCode,
+              stderr: hookResult.stderr,
+            }),
             "error",
           );
         }
       } catch (err) {
-        notify?.(`PreToolUse 执行错误: ${String(err)}`, "error");
+        notify?.(
+          formatMessage(msg.preToolUseError, { error: String(err) }),
+          "error",
+        );
       }
     }
   }
@@ -111,6 +128,7 @@ export async function triggerPostToolUseHooks(
   notify?: NotifyFn,
 ): Promise<PostToolUseResult> {
   const groups = getHookGroups(settings, "PostToolUse");
+  const msg = resolveMessages(settings);
   const result: PostToolUseResult = {};
 
   for (const group of groups) {
@@ -124,7 +142,12 @@ export async function triggerPostToolUseHooks(
           await executeParsedHook(hook, context, "PostToolUse");
 
         if (hookResult.exitCode === 2) {
-          notify?.(`PostToolUse 反馈: ${hookResult.stderr}`, "warning");
+          notify?.(
+            formatMessage(msg.postToolUseFeedback, {
+              stderr: hookResult.stderr,
+            }),
+            "warning",
+          );
           continue;
         }
 
@@ -152,17 +175,26 @@ export async function triggerPostToolUseHooks(
           if (patch.details !== undefined) result.details = patch.details;
           if (patch.isError !== undefined) result.isError = patch.isError;
         } else if (hookResult.exitCode === 0 && plainStdout) {
-          notify?.(`PostToolUse 输出: ${plainStdout}`, "info");
+          notify?.(
+            formatMessage(msg.postToolUseOutput, { output: plainStdout }),
+            "info",
+          );
         }
 
         if (hookResult.exitCode !== 0 && hookResult.exitCode !== 2) {
           notify?.(
-            `PostToolUse 失败 (exit ${hookResult.exitCode}): ${hookResult.stderr}`,
+            formatMessage(msg.postToolUseFailed, {
+              exitCode: hookResult.exitCode,
+              stderr: hookResult.stderr,
+            }),
             "error",
           );
         }
       } catch (err) {
-        notify?.(`PostToolUse 执行错误: ${String(err)}`, "error");
+        notify?.(
+          formatMessage(msg.postToolUseError, { error: String(err) }),
+          "error",
+        );
       }
     }
   }
@@ -177,6 +209,7 @@ export async function triggerPostToolUseFailureHooks(
   notify?: NotifyFn,
 ): Promise<PostToolUseResult> {
   const groups = getHookGroups(settings, "PostToolUseFailure");
+  const msg = resolveMessages(settings);
   const result: PostToolUseResult = {};
 
   for (const group of groups) {
@@ -190,7 +223,12 @@ export async function triggerPostToolUseFailureHooks(
           await executeParsedHook(hook, context, "PostToolUseFailure");
 
         if (hookResult.exitCode === 2) {
-          notify?.(`PostToolUseFailure 反馈: ${hookResult.stderr}`, "warning");
+          notify?.(
+            formatMessage(msg.postToolUseFailureFeedback, {
+              stderr: hookResult.stderr,
+            }),
+            "warning",
+          );
           continue;
         }
 
@@ -221,17 +259,28 @@ export async function triggerPostToolUseFailureHooks(
           if (patch.details !== undefined) result.details = patch.details;
           if (patch.isError !== undefined) result.isError = patch.isError;
         } else if (hookResult.exitCode === 0 && plainStdout) {
-          notify?.(`PostToolUseFailure 输出: ${plainStdout}`, "info");
+          notify?.(
+            formatMessage(msg.postToolUseFailureOutput, {
+              output: plainStdout,
+            }),
+            "info",
+          );
         }
 
         if (hookResult.exitCode !== 0 && hookResult.exitCode !== 2) {
           notify?.(
-            `PostToolUseFailure 失败 (exit ${hookResult.exitCode}): ${hookResult.stderr}`,
+            formatMessage(msg.postToolUseFailureFailed, {
+              exitCode: hookResult.exitCode,
+              stderr: hookResult.stderr,
+            }),
             "error",
           );
         }
       } catch (err) {
-        notify?.(`PostToolUseFailure 执行错误: ${String(err)}`, "error");
+        notify?.(
+          formatMessage(msg.postToolUseFailureError, { error: String(err) }),
+          "error",
+        );
       }
     }
   }
@@ -261,7 +310,9 @@ export function registerToolHooks(pi: ExtensionAPI, shared: HookModuleContext) {
     }
 
     if (result.stopProcessing) {
-      const stopReason = result.stopReason ?? "Stopped by hook";
+      const stopReason =
+        result.stopReason ??
+        resolveMessages(shared.currentSettings).preToolUseStoppedReason;
       ctx.abort?.();
       return { block: true, reason: stopReason };
     }

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,104 @@
+import type { SettingsFile } from "./types";
+
+// ============================================================================
+// 可配置的通知文本 (configurable notification messages)
+//
+// Every user-facing string the extension shows via `notify` (plus the default
+// block/stop reasons returned to pi) lives in DEFAULT_MESSAGES below.
+// Override any subset through the top-level `messages` key in settings:
+//
+//   {
+//     "hooks": { ... },
+//     "messages": {
+//       "preToolUseBlocked": "Blocked: {reason}",
+//       "hookError": "Hook crashed: {error}"
+//     }
+//   }
+//
+// Templates use `{var}` placeholders. Supported vars per message:
+//   reason, output, stderr, error, exitCode, decision.
+// Unknown placeholders are left untouched; defaults stay exactly as before
+// so existing installs see no behavior change.
+// ============================================================================
+
+export type MessageKey =
+  | "preToolUseBlocked"
+  | "preToolUseDenied"
+  | "preToolUsePlainOutput"
+  | "preToolUseFailed"
+  | "preToolUseError"
+  | "postToolUseFeedback"
+  | "postToolUseOutput"
+  | "postToolUseFailed"
+  | "postToolUseError"
+  | "postToolUseFailureFeedback"
+  | "postToolUseFailureOutput"
+  | "postToolUseFailureFailed"
+  | "postToolUseFailureError"
+  | "userPromptSubmitInvalidDecision"
+  | "userPromptSubmitPlainOutput"
+  | "userPromptSubmitFailed"
+  | "userPromptSubmitError"
+  | "userPromptSubmitBlocked"
+  | "stopInvalidDecision"
+  | "stopPlainOutput"
+  | "stopFailed"
+  | "stopError"
+  | "hookFailed"
+  | "hookOutput"
+  | "hookError"
+  | "defaultBlockedReason"
+  | "preToolUseStoppedReason"
+  | "stopBlockReason";
+
+export type HookMessages = {
+  [K in MessageKey]?: string;
+};
+
+export const DEFAULT_MESSAGES: Record<MessageKey, string> = {
+  preToolUseBlocked: "PreToolUse 阻止: {reason}",
+  preToolUseDenied: "PreToolUse 拒绝: {reason}",
+  preToolUsePlainOutput: "PreToolUse 输出 (非JSON): {output}",
+  preToolUseFailed: "PreToolUse 失败 (exit {exitCode}): {stderr}",
+  preToolUseError: "PreToolUse 执行错误: {error}",
+  postToolUseFeedback: "PostToolUse 反馈: {stderr}",
+  postToolUseOutput: "PostToolUse 输出: {output}",
+  postToolUseFailed: "PostToolUse 失败 (exit {exitCode}): {stderr}",
+  postToolUseError: "PostToolUse 执行错误: {error}",
+  postToolUseFailureFeedback: "PostToolUseFailure 反馈: {stderr}",
+  postToolUseFailureOutput: "PostToolUseFailure 输出: {output}",
+  postToolUseFailureFailed: "PostToolUseFailure 失败 (exit {exitCode}): {stderr}",
+  postToolUseFailureError: "PostToolUseFailure 执行错误: {error}",
+  userPromptSubmitInvalidDecision:
+    "UserPromptSubmit 忽略无效 decision: {decision}",
+  userPromptSubmitPlainOutput: "UserPromptSubmit 输出 (非JSON): {output}",
+  userPromptSubmitFailed: "UserPromptSubmit 失败 (exit {exitCode}): {stderr}",
+  userPromptSubmitError: "UserPromptSubmit 执行错误: {error}",
+  userPromptSubmitBlocked: "UserPromptSubmit 阻止: {reason}",
+  stopInvalidDecision: "Stop 忽略无效 decision: {decision}",
+  stopPlainOutput: "Stop 输出 (非JSON): {output}",
+  stopFailed: "Stop 失败 (exit {exitCode}): {stderr}",
+  stopError: "Stop 执行错误: {error}",
+  hookFailed: "Hook 失败 (exit {exitCode}): {stderr}",
+  hookOutput: "Hook 输出: {output}",
+  hookError: "Hook 执行错误: {error}",
+  defaultBlockedReason: "Blocked by hook",
+  preToolUseStoppedReason: "Stopped by hook",
+  stopBlockReason: "Continue requested by Stop hook",
+};
+
+export function resolveMessages(
+  settings: SettingsFile | undefined,
+): Record<MessageKey, string> {
+  return { ...DEFAULT_MESSAGES, ...settings?.messages };
+}
+
+export function formatMessage(
+  template: string,
+  vars: Record<string, string | number | undefined>,
+): string {
+  return template.replace(/\{(\w+)\}/g, (match, name: string) => {
+    const value = vars[name];
+    return value === undefined ? match : String(value);
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { HookMessages } from "./messages";
+
 // ============================================================================
 // 类型定义
 // ============================================================================
@@ -45,6 +47,8 @@ export type HooksConfig = {
 
 export type SettingsFile = {
   hooks?: HooksConfig;
+  /** Partial overrides for the user-facing notification strings (see messages.ts). */
+  messages?: HookMessages;
 };
 
 export type HookEventName =


### PR DESCRIPTION
Hey there, I had an AI tool make this PR, wanted to be able to change the strings displayed :)

---

# Issue 

All user-facing `notify` strings are currently hardcoded (Chinese literals scattered across the six hook modules). This makes them overridable without forking for text changes.

## What changed
- **New `src/messages.ts`**: `MessageKey` union (28 keys), `DEFAULT_MESSAGES` (byte-identical to the old literals), `resolveMessages(settings)` (defaults + overrides), `formatMessage(template, vars)` with `{reason}`/`{output}`/`{stderr}`/`{error}`/`{exitCode}`/`{decision}` placeholders (unknown placeholders pass through untouched).
- **`SettingsFile.messages?`**: top-level partial overrides, e.g.
  ```json
  { "messages": { "preToolUseBlocked": "Blocked: {reason}" } }
  ```
- **`loadSettings`**: merges `messages` project-over-global per key, alongside `hooks`.
- **Call sites** (`shared.ts`, `tool-hooks.ts`, `prompt-hooks.ts`, `stop-hooks.ts`): resolve once per trigger, format at each `notify`. Default block/stop reasons (`Blocked by hook`, `Stopped by hook`, `Continue requested by Stop hook`) are configurable too.
- **Docs**: `Custom Messages` / `自定义通知文本` sections in both READMEs.

## Compatibility
Defaults are exactly the old strings, so installs without a `messages` key see zero behavior change. Verified with `tsc --noEmit` plus a runtime script covering: defaults preserved, per-key override, unknown-placeholder passthrough, end-to-end exit-2 block + invalid-decision notifies with custom text, and project-settings merge.